### PR TITLE
Add Mcap and serialization utilities

### DIFF
--- a/docker/version.sh
+++ b/docker/version.sh
@@ -3,4 +3,4 @@ VERSION=1.0.3
 IMAGE=eolo-dev
 
 # This is the version of the dep image. Increase this number everytime you change `external/CMakeLists.txt`
-DEPS_VERSION=1.0.5
+DEPS_VERSION=1.0.6

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -177,7 +177,7 @@ add_cmake_dependency(
 # --------------------------------------------------------------------------------------------------
 # mcap
 set(MCAP_VERSION 1.3.0)
-set(MCAP_TAG ada3a729e06cd640c0e787905da8ab2d1c48293d)
+set(MCAP_TAG b0e82f0a7af74d20152a582926b8bd3b5f2756fe)
 add_cmake_dependency(
   NAME mcap
   VERSION ${MCAP_VERSION}

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -173,3 +173,15 @@ add_cmake_dependency(
   GIT_TAG ${RANGE-V3_VERSION}
   CMAKE_ARGS ${RANGE-V3_CMAKE_ARGS}
 )
+
+# --------------------------------------------------------------------------------------------------
+# mcap
+set(MCAP_VERSION 1.3.0)
+set(MCAP_TAG ada3a729e06cd640c0e787905da8ab2d1c48293d)
+add_cmake_dependency(
+  NAME mcap
+  VERSION ${MCAP_VERSION}
+  GIT_REPOSITORY "https://github.com/filippobrizzi/mcap.git"
+  GIT_TAG ${MCAP_TAG}
+  SOURCE_SUBDIR cpp
+)

--- a/modules/examples/CMakeLists.txt
+++ b/modules/examples/CMakeLists.txt
@@ -1,11 +1,12 @@
 declare_module(
   NAME examples
   DEPENDS_ON_MODULES base ipc serdes
-  DEPENDS_ON_EXTERNAL_PROJECTS Eigen3 fmt Protobuf
+  DEPENDS_ON_EXTERNAL_PROJECTS Eigen3 fmt mcap Protobuf
   EXCLUDE_FROM_ALL
 )
 
 find_package(Eigen3 REQUIRED)
+find_package(mcap REQUIRED)
 find_package(fmt REQUIRED)
 
 add_subdirectory(proto)

--- a/modules/examples/examples/CMakeLists.txt
+++ b/modules/examples/examples/CMakeLists.txt
@@ -17,6 +17,13 @@ define_module_example(
         PUBLIC_LINK_LIBS eolo::ipc)
 
 define_module_example(
+        NAME zenoh_sub_any
+        SOURCES zenoh_sub_any.cpp zenoh_program_options.h
+        PUBLIC_INCLUDE_PATHS
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+        PUBLIC_LINK_LIBS eolo::ipc)
+
+define_module_example(
         NAME mcap_writer
         SOURCES mcap_writer.cpp
         PUBLIC_INCLUDE_PATHS

--- a/modules/examples/examples/CMakeLists.txt
+++ b/modules/examples/examples/CMakeLists.txt
@@ -15,3 +15,10 @@ define_module_example(
         PUBLIC_INCLUDE_PATHS
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         PUBLIC_LINK_LIBS eolo::ipc)
+
+        define_module_example(
+            NAME mcap_writer
+            SOURCES mcap_writer.cpp
+            PUBLIC_INCLUDE_PATHS
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+            PUBLIC_LINK_LIBS mcap)

--- a/modules/examples/examples/CMakeLists.txt
+++ b/modules/examples/examples/CMakeLists.txt
@@ -16,9 +16,16 @@ define_module_example(
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         PUBLIC_LINK_LIBS eolo::ipc)
 
-        define_module_example(
-            NAME mcap_writer
-            SOURCES mcap_writer.cpp
-            PUBLIC_INCLUDE_PATHS
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-            PUBLIC_LINK_LIBS mcap)
+define_module_example(
+        NAME mcap_writer
+        SOURCES mcap_writer.cpp
+        PUBLIC_INCLUDE_PATHS
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+        PUBLIC_LINK_LIBS mcap)
+
+define_module_example(
+        NAME mcap_reader
+        SOURCES mcap_reader.cpp
+        PUBLIC_INCLUDE_PATHS
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+        PUBLIC_LINK_LIBS mcap)

--- a/modules/examples/examples/mcap_reader.cpp
+++ b/modules/examples/examples/mcap_reader.cpp
@@ -1,0 +1,27 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#define MCAP_IMPLEMENTATION
+#define MCAP_COMPRESSION_NO_ZSTD
+#define MCAP_COMPRESSION_NO_LZ4
+#include <fmt/core.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
+#include <mcap/reader.hpp>
+
+auto main(int argc, const char* argv[]) -> int {
+  if (argc != 2) {
+    fmt::println(stderr, "Usage: {} <input.mcap>",
+                 argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    std::exit(1);
+  }
+  std::filesystem::path input{ argv[1] };  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
+  mcap::McapReader reader;
+  const auto res = reader.open(input.string());
+  if (!res.ok()) {
+    fmt::println(stderr, "Failed to open: {} for writing", input.c_str());
+    std::exit(1);
+  }
+}

--- a/modules/examples/examples/mcap_writer.cpp
+++ b/modules/examples/examples/mcap_writer.cpp
@@ -1,0 +1,100 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+
+#include "eolo/serdes/serdes.h"
+#define MCAP_IMPLEMENTATION
+#define MCAP_COMPRESSION_NO_ZSTD
+#define MCAP_COMPRESSION_NO_LZ4
+#include <fmt/core.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
+#include <mcap/writer.hpp>
+
+#include "eolo/examples/types/proto/pose.pb.h"
+#include "eolo/examples/types_protobuf/pose.h"
+
+/// Builds a FileDescriptorSet of this descriptor and all transitive dependencies, for use as a
+/// channel schema.
+auto buildFileDescriptorSet(const google::protobuf::Descriptor* toplevel_descriptor)
+    -> google::protobuf::FileDescriptorSet {
+  google::protobuf::FileDescriptorSet fd_set;
+  std::queue<const google::protobuf::FileDescriptor*> to_add;
+  to_add.push(toplevel_descriptor->file());
+  std::unordered_set<std::string> seen_dependencies;
+
+  while (!to_add.empty()) {
+    const google::protobuf::FileDescriptor* next = to_add.front();
+    to_add.pop();
+    next->CopyTo(fd_set.add_file());
+    for (int i = 0; i < next->dependency_count(); ++i) {
+      const auto& dep = next->dependency(i);
+      if (seen_dependencies.find(dep->name()) == seen_dependencies.end()) {
+        seen_dependencies.insert(dep->name());
+        to_add.push(dep);
+      }
+    }
+  }
+
+  return fd_set;
+}
+
+template <class Clock>
+auto toMcapTimestamp(const typename std::chrono::time_point<Clock>& time_point) -> mcap::Timestamp {
+  return static_cast<mcap::Timestamp>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(time_point.time_since_epoch()).count());
+}
+
+auto main(int argc, const char* argv[]) -> int {
+  if (argc != 2) {
+    fmt::println(stderr, "Usage: {} <output.mcap>",
+                 argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    std::exit(1);
+  }
+  std::filesystem::path output{ argv[1] };  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
+  mcap::McapWriter writer;
+  auto options = mcap::McapWriterOptions("");
+  const auto res = writer.open(output.string(), options);
+  if (!res.ok()) {
+    fmt::println(stderr, "Failed to open: {} for writing", output.c_str());
+    std::exit(1);
+  }
+
+  mcap::Schema pose_schema(
+      "eolo.examples.types.proto.Pose", "protobuf",
+      buildFileDescriptorSet(eolo::examples::types::proto::Pose::descriptor()).SerializeAsString());
+  writer.addSchema(pose_schema);
+
+  mcap::Channel pose_channel("pose", "protobuf", pose_schema.id);
+  writer.addChannel(pose_channel);
+  auto pose_channel_id = pose_channel.id;
+
+  const auto start_time = toMcapTimestamp(std::chrono::system_clock::now());
+  constexpr mcap::Timestamp INTERVAL = std::chrono::nanoseconds{ 1000000 }.count();
+  constexpr uint32_t TOTAL_MSGS = 100;
+  for (uint32_t i = 0; i < TOTAL_MSGS; ++i) {
+    mcap::Timestamp frame_time = start_time + i * INTERVAL;
+
+    eolo::examples::types::Pose pose;
+    pose.position = Eigen::Vector3d{ static_cast<double>(i), 2, 3 };
+    auto data = eolo::serdes::serialize(pose);
+    mcap::Message msg;
+    msg.channelId = pose_channel_id;
+    msg.sequence = i;
+    msg.publishTime = frame_time;
+    msg.logTime = frame_time;
+    msg.data = data.data();
+    msg.dataSize = data.size();
+
+    const auto write_res = writer.write(msg);
+    if (!write_res.ok()) {
+      fmt::println(stderr, "failed to write msg with error: {}", write_res.message);
+      break;
+    }
+  }
+}

--- a/modules/examples/examples/zenoh_pub.cpp
+++ b/modules/examples/examples/zenoh_pub.cpp
@@ -15,6 +15,7 @@
 #include "eolo/ipc/publisher.h"
 #include "eolo/ipc/zenoh/publisher.h"
 #include "eolo/ipc/zenoh/session.h"
+#include "eolo/serdes/serdes.h"
 #include "zenoh_program_options.h"
 
 auto main(int argc, const char* argv[]) -> int {
@@ -25,7 +26,8 @@ auto main(int argc, const char* argv[]) -> int {
     auto config = parseArgs(args);
     auto session = eolo::ipc::zenoh::createSession(config);
 
-    eolo::ipc::zenoh::Publisher publisher{ session, config, [](const auto& status) {
+    auto type_info = eolo::serdes::getSerializedTypeInfo<eolo::examples::types::Pose>();
+    eolo::ipc::zenoh::Publisher publisher{ session, config, type_info, [](const auto& status) {
                                             if (status.matching) {
                                               fmt::println("Subscriber match");
                                             } else {
@@ -39,6 +41,8 @@ auto main(int argc, const char* argv[]) -> int {
     while (true) {
       eolo::examples::types::Pose pose;
       pose.position = Eigen::Vector3d{ 1, 2, 3 };
+      pose.orientation =
+          Eigen::Quaterniond{ 1., 0.1, 0.2, 0.3 };  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 
       fmt::println("Publishing Data ('{} : {})", config.topic, pose);
       auto res = eolo::ipc::publish(publisher, pose);

--- a/modules/examples/examples/zenoh_sub_any.cpp
+++ b/modules/examples/examples/zenoh_sub_any.cpp
@@ -9,21 +9,15 @@
 
 #include <fmt/chrono.h>
 #include <fmt/core.h>
-#include <google/protobuf/descriptor.h>
-#include <google/protobuf/descriptor.pb.h>
-#include <google/protobuf/descriptor_database.h>
-#include <google/protobuf/dynamic_message.h>
-#include <google/protobuf/util/json_util.h>
 #include <zenoh.h>
 #include <zenohc.hxx>
 
 #include "eolo/base/exception.h"
-#include "eolo/examples/types/pose.h"
 #include "eolo/examples/types_protobuf/pose.h"
-#include "eolo/ipc/subscriber.h"
 #include "eolo/ipc/zenoh/query.h"
 #include "eolo/ipc/zenoh/session.h"
 #include "eolo/ipc/zenoh/subscriber.h"
+#include "eolo/serdes/dynamic_deserializer.h"
 #include "eolo/serdes/type_info.h"
 #include "zenoh_program_options.h"
 
@@ -35,25 +29,7 @@
       response.size() != 1,
       std::format("received {} responses for type from service {}", response.size(), service_topic));
 
-  return eolo::serdes::fromJson(response.front().value);
-}
-
-void loadSchema(const eolo::serdes::TypeInfo& type_info,
-                google::protobuf::SimpleDescriptorDatabase& proto_db) {
-  google::protobuf::FileDescriptorSet fd_set;
-  auto res = fd_set.ParseFromArray(type_info.schema.data(), static_cast<int>(type_info.schema.size()));
-  eolo::throwExceptionIf<eolo::InvalidDataException>(
-      !res, std::format("failed to parse schema for type: {}", type_info.name));
-
-  google::protobuf::FileDescriptorProto unused;
-  for (int i = 0; i < fd_set.file_size(); ++i) {
-    const auto& file = fd_set.file(i);
-    if (!proto_db.FindFileByName(file.name(), &unused)) {
-      res = proto_db.Add(file);
-      eolo::throwExceptionIf<eolo::InvalidDataException>(
-          !res, std::format("failed to add definition to proto DB: {}", file.name()));
-    }
-  }
+  return eolo::serdes::TypeInfo::fromJson(response.front().value);
 }
 
 auto main(int argc, const char* argv[]) -> int {
@@ -70,28 +46,12 @@ auto main(int argc, const char* argv[]) -> int {
 
     // TODO: this needs to be done when we receive the first data as the publisher may not be publishing.
     auto type_info = getTopicTypeInfo(*session, config.topic);
-    google::protobuf::SimpleDescriptorDatabase proto_db;
-    google::protobuf::DescriptorPool proto_pool(&proto_db);
-    google::protobuf::DynamicMessageFactory proto_factory(&proto_pool);
+    eolo::serdes::DynamicDeserializer dynamic_deserializer;
+    dynamic_deserializer.registerSchema(type_info);
 
-    loadSchema(type_info, proto_db);
-    const auto* descriptor = proto_pool.FindMessageTypeByName(type_info.name);
-
-    auto cb = [descriptor, &proto_factory](const eolo::ipc::MessageMetadata& metadata,
-                                           std::span<const std::byte> buffer) mutable {
-      google::protobuf::Message* message = proto_factory.GetPrototype(descriptor)->New();
-      const auto res = message->ParseFromArray(buffer.data(), static_cast<int>(buffer.size()));
-      eolo::throwExceptionIf<eolo::InvalidDataException>(!res, std::format("failed to parse message"));
-
-      std::vector<const google::protobuf::FieldDescriptor*> fields;
-      message->GetReflection()->ListFields(*message, &fields);
-
-      std::string msg_json;
-      google::protobuf::util::JsonPrintOptions options;
-      options.always_print_primitive_fields = true;
-      auto status = google::protobuf::util::MessageToJsonString(*message, &msg_json);
-      eolo::throwExceptionIf<eolo::InvalidDataException>(
-          !status.ok(), std::format("failed to convert proto message to json: {}", status.message()));
+    auto cb = [&dynamic_deserializer, type = type_info.name](const eolo::ipc::MessageMetadata& metadata,
+                                                             std::span<const std::byte> buffer) mutable {
+      auto msg_json = dynamic_deserializer.toJson(type, buffer);
       fmt::println("From: {}. Topic: {} - {}", metadata.sender_id, metadata.topic, msg_json);
     };
 

--- a/modules/examples/examples/zenoh_sub_any.cpp
+++ b/modules/examples/examples/zenoh_sub_any.cpp
@@ -1,0 +1,111 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributor
+//=================================================================================================
+
+#include <chrono>
+#include <cstdlib>
+#include <format>
+#include <thread>
+
+#include <fmt/chrono.h>
+#include <fmt/core.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/descriptor_database.h>
+#include <google/protobuf/dynamic_message.h>
+#include <google/protobuf/util/json_util.h>
+#include <zenoh.h>
+#include <zenohc.hxx>
+
+#include "eolo/base/exception.h"
+#include "eolo/examples/types/pose.h"
+#include "eolo/examples/types_protobuf/pose.h"
+#include "eolo/ipc/subscriber.h"
+#include "eolo/ipc/zenoh/query.h"
+#include "eolo/ipc/zenoh/session.h"
+#include "eolo/ipc/zenoh/subscriber.h"
+#include "eolo/serdes/type_info.h"
+#include "zenoh_program_options.h"
+
+[[nodiscard]] auto getTopicTypeInfo(zenohc::Session& session,
+                                    const std::string& topic) -> eolo::serdes::TypeInfo {
+  auto service_topic = eolo::ipc::getTypeInfoServiceTopic(topic);
+  auto response = eolo::ipc::zenoh::query(session, service_topic, "");
+  eolo::throwExceptionIf<eolo::InvalidDataException>(
+      response.size() != 1,
+      std::format("received {} responses for type from service {}", response.size(), service_topic));
+
+  return eolo::serdes::fromJson(response.front().value);
+}
+
+void loadSchema(const eolo::serdes::TypeInfo& type_info,
+                google::protobuf::SimpleDescriptorDatabase& proto_db) {
+  google::protobuf::FileDescriptorSet fd_set;
+  auto res = fd_set.ParseFromArray(type_info.schema.data(), static_cast<int>(type_info.schema.size()));
+  eolo::throwExceptionIf<eolo::InvalidDataException>(
+      !res, std::format("failed to parse schema for type: {}", type_info.name));
+
+  google::protobuf::FileDescriptorProto unused;
+  for (int i = 0; i < fd_set.file_size(); ++i) {
+    const auto& file = fd_set.file(i);
+    if (!proto_db.FindFileByName(file.name(), &unused)) {
+      res = proto_db.Add(file);
+      eolo::throwExceptionIf<eolo::InvalidDataException>(
+          !res, std::format("failed to add definition to proto DB: {}", file.name()));
+    }
+  }
+}
+
+auto main(int argc, const char* argv[]) -> int {
+  try {
+    auto desc = getProgramDescription("Periodic publisher example");
+    const auto args = std::move(desc).parse(argc, argv);
+
+    auto config = parseArgs(args);
+
+    fmt::println("Opening session...");
+    fmt::println("Declaring Subscriber on '{}'", config.topic);
+
+    auto session = eolo::ipc::zenoh::createSession(config);
+
+    // TODO: this needs to be done when we receive the first data as the publisher may not be publishing.
+    auto type_info = getTopicTypeInfo(*session, config.topic);
+    google::protobuf::SimpleDescriptorDatabase proto_db;
+    google::protobuf::DescriptorPool proto_pool(&proto_db);
+    google::protobuf::DynamicMessageFactory proto_factory(&proto_pool);
+
+    loadSchema(type_info, proto_db);
+    const auto* descriptor = proto_pool.FindMessageTypeByName(type_info.name);
+
+    auto cb = [descriptor, &proto_factory](const eolo::ipc::MessageMetadata& metadata,
+                                           std::span<const std::byte> buffer) mutable {
+      google::protobuf::Message* message = proto_factory.GetPrototype(descriptor)->New();
+      const auto res = message->ParseFromArray(buffer.data(), static_cast<int>(buffer.size()));
+      eolo::throwExceptionIf<eolo::InvalidDataException>(!res, std::format("failed to parse message"));
+
+      std::vector<const google::protobuf::FieldDescriptor*> fields;
+      message->GetReflection()->ListFields(*message, &fields);
+
+      std::string msg_json;
+      google::protobuf::util::JsonPrintOptions options;
+      options.always_print_primitive_fields = true;
+      auto status = google::protobuf::util::MessageToJsonString(*message, &msg_json);
+      eolo::throwExceptionIf<eolo::InvalidDataException>(
+          !status.ok(), std::format("failed to convert proto message to json: {}", status.message()));
+      fmt::println("From: {}. Topic: {} - {}", metadata.sender_id, metadata.topic, msg_json);
+    };
+
+    auto subscriber = eolo::ipc::zenoh::Subscriber{ std::move(session), std::move(config), std::move(cb) };
+
+    (void)subscriber;
+
+    while (true) {
+      std::this_thread::sleep_for(std::chrono::seconds{ 1 });
+    }
+
+    return EXIT_SUCCESS;
+  } catch (const std::exception& ex) {
+    std::ignore = std::fputs(ex.what(), stderr);
+    return EXIT_FAILURE;
+  }
+}

--- a/modules/examples/examples/zenoh_sub_any.cpp
+++ b/modules/examples/examples/zenoh_sub_any.cpp
@@ -13,7 +13,6 @@
 #include <zenohc.hxx>
 
 #include "eolo/base/exception.h"
-#include "eolo/examples/types_protobuf/pose.h"
 #include "eolo/ipc/zenoh/query.h"
 #include "eolo/ipc/zenoh/session.h"
 #include "eolo/ipc/zenoh/subscriber.h"
@@ -56,7 +55,6 @@ auto main(int argc, const char* argv[]) -> int {
     };
 
     auto subscriber = eolo::ipc::zenoh::Subscriber{ std::move(session), std::move(config), std::move(cb) };
-
     (void)subscriber;
 
     while (true) {

--- a/modules/examples/include/eolo/examples/types_protobuf/pose.h
+++ b/modules/examples/include/eolo/examples/types_protobuf/pose.h
@@ -6,13 +6,20 @@
 
 #include "eolo/examples/types/pose.h"
 #include "eolo/examples/types/proto/pose.pb.h"
-#include "eolo/serdes/protobuf/buffers.h"
+#include "eolo/serdes/protobuf/protobuf.h"
+
+namespace eolo::serdes::protobuf {
+template <>
+struct ProtoAssociation<eolo::examples::types::Pose> {
+  using Type = eolo::examples::types::proto::Pose;
+};
+}  // namespace eolo::serdes::protobuf
 
 namespace eolo::examples::types {
 void toProto(proto::Pose& proto_pose, const Pose& pose);
 void fromProto(const proto::Pose& proto_pose, Pose& pose);
 
-void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const Pose& pose);
-void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, Pose& pose);
+// void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const Pose& pose);
+// void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, Pose& pose);
 
 }  // namespace eolo::examples::types

--- a/modules/examples/include/eolo/examples/types_protobuf/pose.h
+++ b/modules/examples/include/eolo/examples/types_protobuf/pose.h
@@ -6,7 +6,7 @@
 
 #include "eolo/examples/types/pose.h"
 #include "eolo/examples/types/proto/pose.pb.h"
-#include "eolo/serdes/protobuf/protobuf.h"
+#include "eolo/serdes/protobuf/concepts.h"
 
 namespace eolo::serdes::protobuf {
 template <>
@@ -18,8 +18,4 @@ struct ProtoAssociation<eolo::examples::types::Pose> {
 namespace eolo::examples::types {
 void toProto(proto::Pose& proto_pose, const Pose& pose);
 void fromProto(const proto::Pose& proto_pose, Pose& pose);
-
-// void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const Pose& pose);
-// void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, Pose& pose);
-
 }  // namespace eolo::examples::types

--- a/modules/examples/src/types_protobuf/pose.cpp
+++ b/modules/examples/src/types_protobuf/pose.cpp
@@ -18,12 +18,4 @@ void fromProto(const proto::Pose& proto_pose, Pose& pose) {
   fromProto(proto_pose.orientation(), pose.orientation);
 }
 
-// void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const Pose& pose) {
-//   serdes::protobuf::toProtobuf<proto::Pose>(buffer, pose);
-// }
-
-// void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, Pose& pose) {
-//   serdes::protobuf::fromProtobuf<proto::Pose>(buffer, pose);
-// }
-
 }  // namespace eolo::examples::types

--- a/modules/examples/src/types_protobuf/pose.cpp
+++ b/modules/examples/src/types_protobuf/pose.cpp
@@ -5,7 +5,6 @@
 #include "eolo/examples/types_protobuf/pose.h"
 
 #include "eolo/examples/types_protobuf/geometry.h"
-#include "eolo/serdes/protobuf/protobuf.h"
 
 namespace eolo::examples::types {
 void toProto(proto::Pose& proto_pose, const Pose& pose) {

--- a/modules/examples/src/types_protobuf/pose.cpp
+++ b/modules/examples/src/types_protobuf/pose.cpp
@@ -18,11 +18,12 @@ void fromProto(const proto::Pose& proto_pose, Pose& pose) {
   fromProto(proto_pose.orientation(), pose.orientation);
 }
 
-void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const Pose& pose) {
-  serdes::protobuf::toProtobuf<proto::Pose>(buffer, pose);
-}
+// void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const Pose& pose) {
+//   serdes::protobuf::toProtobuf<proto::Pose>(buffer, pose);
+// }
 
-void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, Pose& pose) {
-  serdes::protobuf::fromProtobuf<proto::Pose>(buffer, pose);
-}
+// void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, Pose& pose) {
+//   serdes::protobuf::fromProtobuf<proto::Pose>(buffer, pose);
+// }
+
 }  // namespace eolo::examples::types

--- a/modules/examples/tests/types_protobuf_tests.cpp
+++ b/modules/examples/tests/types_protobuf_tests.cpp
@@ -124,31 +124,4 @@ TEST(Pose, Pose) {
   EXPECT_EQ(pose, pose_des);
 }
 
-TEST(Pose, PoseBuffer) {
-  std::mt19937_64 mt{ std::random_device{}() };
-  auto pose = randomPose(mt);
-
-  serdes::protobuf::SerializerBuffer ser_buffer;
-  toProtobuf(ser_buffer, pose);
-
-  auto buffer = std::move(ser_buffer).exctractSerializedData();
-
-  serdes::protobuf::DeserializerBuffer des_buffer{ buffer };
-  Pose pose_des;
-  fromProtobuf(des_buffer, pose_des);
-
-  EXPECT_EQ(pose, pose_des);
-}
-
-TEST(Pose, PoseSerdes) {
-  std::mt19937_64 mt{ std::random_device{}() };
-  auto pose = randomPose(mt);
-
-  auto buffer = serdes::serialize(pose);
-
-  Pose pose_des;
-  serdes::deserialize(buffer, pose_des);
-  EXPECT_EQ(pose, pose_des);
-}
-
 }  // namespace eolo::examples::types::tests

--- a/modules/ipc/CMakeLists.txt
+++ b/modules/ipc/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 declare_module(
   NAME ipc
-  DEPENDS_ON_MODULES base cli
+  DEPENDS_ON_MODULES base cli serdes
   DEPENDS_ON_EXTERNAL_PROJECTS absl fmt nlohmann_json range-v3 zenohcxx
 )
 
@@ -40,11 +40,13 @@ define_module_library(
   NAME ipc
   PUBLIC_LINK_LIBS
     absl::base
+    absl::status
     eolo::base
     eolo::cli
     fmt::fmt
     nlohmann_json::nlohmann_json
     range-v3::range-v3
+    eolo::serdes
     zenohc::lib
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}

--- a/modules/ipc/CMakeLists.txt
+++ b/modules/ipc/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     src/zenoh/liveliness.cpp
     src/zenoh/publisher.cpp
     src/zenoh/query.cpp
+    src/zenoh/service.cpp
     src/zenoh/scout.cpp
     src/zenoh/subscriber.cpp
     src/zenoh/utils.cpp
@@ -29,6 +30,7 @@ set(SOURCES
     include/eolo/ipc/zenoh/utils.h
     include/eolo/ipc/zenoh/publisher.h
     include/eolo/ipc/zenoh/query.h
+    include/eolo/ipc/zenoh/service.h
     include/eolo/ipc/zenoh/scout.h
     include/eolo/ipc/zenoh/subscriber.h
 )

--- a/modules/ipc/include/eolo/ipc/common.h
+++ b/modules/ipc/include/eolo/ipc/common.h
@@ -11,16 +11,9 @@ namespace eolo::ipc {
 
 enum class Mode : uint8_t { PEER = 0, CLIENT, ROUTER };
 enum class Protocol : uint8_t { ANY = 0, UDP, TCP };
-struct TypeInfo {
-  std::string name;
-  std::string schema;
-};
-[[nodiscard]] auto toJson(const TypeInfo& info) -> std::string;
-[[nodiscard]] auto fromJson(const std::string& info) -> TypeInfo;
 
 struct Config {
   std::string topic;
-  TypeInfo type_info;
   bool enable_shared_memory = false;  //! NOTE: With shared-memory enabled, the publisher still uses the
                                       //! network transport layer to notify subscribers of the shared-memory
                                       //! segment to read. Therefore, for very small messages, shared -
@@ -38,8 +31,13 @@ struct Config {
 struct MessageMetadata {
   // TODO: convert this to a uuid
   std::string sender_id;
+  std::string topic;
   std::chrono::nanoseconds timestamp{};
   std::size_t sequence_id{};
 };
+
+[[nodiscard]] constexpr auto getTypeInfoServiceTopic(const std::string& topic) -> std::string {
+  return std::format("type_info/{}", topic);
+}
 
 }  // namespace eolo::ipc

--- a/modules/ipc/include/eolo/ipc/common.h
+++ b/modules/ipc/include/eolo/ipc/common.h
@@ -11,9 +11,16 @@ namespace eolo::ipc {
 
 enum class Mode : uint8_t { PEER = 0, CLIENT, ROUTER };
 enum class Protocol : uint8_t { ANY = 0, UDP, TCP };
+struct TypeInfo {
+  std::string name;
+  std::string schema;
+};
+[[nodiscard]] auto toJson(const TypeInfo& info) -> std::string;
+[[nodiscard]] auto fromJson(const std::string& info) -> TypeInfo;
 
 struct Config {
   std::string topic;
+  TypeInfo type_info;
   bool enable_shared_memory = false;  //! NOTE: With shared-memory enabled, the publisher still uses the
                                       //! network transport layer to notify subscribers of the shared-memory
                                       //! segment to read. Therefore, for very small messages, shared -

--- a/modules/ipc/include/eolo/ipc/zenoh/publisher.h
+++ b/modules/ipc/include/eolo/ipc/zenoh/publisher.h
@@ -13,6 +13,7 @@
 #include "eolo/ipc/zenoh/service.h"
 #include "eolo/ipc/zenoh/session.h"
 #include "eolo/ipc/zenoh/utils.h"
+#include "eolo/serdes/serdes.h"
 
 namespace eolo::ipc::zenoh {
 
@@ -25,7 +26,8 @@ class Publisher {
 public:
   using MatchCallback = std::function<void(MatchingStatus)>;
 
-  Publisher(SessionPtr session, Config config, MatchCallback&& match_cb = nullptr);
+  Publisher(SessionPtr session, Config config, serdes::TypeInfo type_info,
+            MatchCallback&& match_cb = nullptr);
   ~Publisher();
   Publisher(const Publisher&) = delete;
   Publisher(Publisher&&) = default;
@@ -44,6 +46,7 @@ private:
   SessionPtr session_;
   std::unique_ptr<zenohc::Publisher> publisher_;
 
+  serdes::TypeInfo type_info_;
   std::unique_ptr<Service> type_service_;
 
   zc_owned_liveliness_token_t liveliness_token_{};

--- a/modules/ipc/include/eolo/ipc/zenoh/publisher.h
+++ b/modules/ipc/include/eolo/ipc/zenoh/publisher.h
@@ -47,6 +47,12 @@ public:
   }
 
 private:
+  void enableCache();
+  void initAttachments();
+  void enableMatchingListener();
+  void createTypeInfoService();
+
+private:
   Config config_;
 
   SessionPtr session_;

--- a/modules/ipc/include/eolo/ipc/zenoh/publisher.h
+++ b/modules/ipc/include/eolo/ipc/zenoh/publisher.h
@@ -10,6 +10,7 @@
 #include <zenohc.hxx>
 
 #include "eolo/ipc/common.h"
+#include "eolo/ipc/zenoh/service.h"
 #include "eolo/ipc/zenoh/session.h"
 #include "eolo/ipc/zenoh/utils.h"
 
@@ -42,6 +43,8 @@ private:
 
   SessionPtr session_;
   std::unique_ptr<zenohc::Publisher> publisher_;
+
+  std::unique_ptr<Service> type_service_;
 
   zc_owned_liveliness_token_t liveliness_token_{};
   ze_owned_publication_cache_t pub_cache_{};

--- a/modules/ipc/include/eolo/ipc/zenoh/publisher.h
+++ b/modules/ipc/include/eolo/ipc/zenoh/publisher.h
@@ -13,7 +13,7 @@
 #include "eolo/ipc/zenoh/service.h"
 #include "eolo/ipc/zenoh/session.h"
 #include "eolo/ipc/zenoh/utils.h"
-#include "eolo/serdes/serdes.h"
+#include "eolo/serdes/type_info.h"
 
 namespace eolo::ipc::zenoh {
 
@@ -21,11 +21,17 @@ struct MatchingStatus {
   bool matching{};  //! If true publisher is connect to at least one subscriber.
 };
 
-// TODO: Add support to get notified for subscribers: https://github.com/eclipse-zenoh/zenoh-c/pull/236
+/// - Create a Zenoh publisher on the topic specified in `config`.
+/// - Create a service that provides the schema used to serialize the data.
+///   - the service is published on the topic created via `getTypeInfoServiceTopic(topic)`
+///     - e.g. for topic `eolo/pose` it create a service on `type_info/eolo/pose`
+///   - the service returns the Json representation of the type info, that can be converted using
+///     serdes::TypeInfo::fromJson(str);
+/// - If `match_cb` is passed, it is called when the first subscriber matches and when the last one unmatch.
 class Publisher {
 public:
   using MatchCallback = std::function<void(MatchingStatus)>;
-
+  ///
   Publisher(SessionPtr session, Config config, serdes::TypeInfo type_info,
             MatchCallback&& match_cb = nullptr);
   ~Publisher();

--- a/modules/ipc/include/eolo/ipc/zenoh/service.h
+++ b/modules/ipc/include/eolo/ipc/zenoh/service.h
@@ -1,0 +1,33 @@
+//================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <zenohc.hxx>
+
+#include "eolo/ipc/zenoh/session.h"
+#include "eolo/ipc/zenoh/utils.h"
+
+namespace eolo::ipc::zenoh {
+
+struct QueryRequest {
+  std::string topic;
+  std::string parameters;
+  std::string value;
+};
+
+class Service {
+public:
+  using Callback = std::function<std::string(const QueryRequest&)>;
+  Service(SessionPtr session, std::string topic, Callback&& callback);
+
+private:
+  SessionPtr session_;
+  std::unique_ptr<zenohc::Queryable> queryable_;
+
+  std::string topic_;
+  Callback callback_;
+};
+
+}  // namespace eolo::ipc::zenoh

--- a/modules/ipc/include/eolo/ipc/zenoh/utils.h
+++ b/modules/ipc/include/eolo/ipc/zenoh/utils.h
@@ -15,12 +15,13 @@
 #include "eolo/ipc/common.h"
 namespace eolo::ipc::zenoh {
 
+/// We use single char key to reduce the overhead of the attachment.
 [[nodiscard]] static constexpr auto messageCounterKey() -> const char* {
-  return "msg_counter";
+  return "0";
 }
 
 [[nodiscard]] static constexpr auto sessionIdKey() -> const char* {
-  return "session_id";
+  return "1";
 }
 
 inline auto toString(const zenohc::Id& id) -> std::string {

--- a/modules/ipc/src/common.cpp
+++ b/modules/ipc/src/common.cpp
@@ -4,19 +4,4 @@
 
 #include "eolo/ipc/common.h"
 
-#include <nlohmann/json.hpp>
-
-namespace eolo::ipc {
-[[nodiscard]] auto toJson(const TypeInfo& info) -> std::string {
-  nlohmann::json data;
-  data["name"] = info.name;
-  data["schema"] = info.schema;
-
-  return data.dump();
-}
-
-[[nodiscard]] auto fromJson(const std::string& info) -> TypeInfo {
-  auto data = nlohmann::json::parse(info);
-  return { .name = data["name"], .schema = data["schema"] };
-}
-}  // namespace eolo::ipc
+namespace eolo::ipc {}  // namespace eolo::ipc

--- a/modules/ipc/src/common.cpp
+++ b/modules/ipc/src/common.cpp
@@ -3,3 +3,20 @@
 //=================================================================================================
 
 #include "eolo/ipc/common.h"
+
+#include <nlohmann/json.hpp>
+
+namespace eolo::ipc {
+[[nodiscard]] auto toJson(const TypeInfo& info) -> std::string {
+  nlohmann::json data;
+  data["name"] = info.name;
+  data["schema"] = info.schema;
+
+  return data.dump();
+}
+
+[[nodiscard]] auto fromJson(const std::string& info) -> TypeInfo {
+  auto data = nlohmann::json::parse(info);
+  return { .name = data["name"], .schema = data["schema"] };
+}
+}  // namespace eolo::ipc

--- a/modules/ipc/src/zenoh/publisher.cpp
+++ b/modules/ipc/src/zenoh/publisher.cpp
@@ -23,47 +23,23 @@ Publisher::Publisher(SessionPtr session, Config config, serdes::TypeInfo type_in
       zc_liveliness_declare_token(session_->loan(), z_keyexpr(config_.topic.c_str()), nullptr);
   throwExceptionIf<FailedZenohOperation>(!z_check(liveliness_token_), "failed to create livelines token");
 
-  // Enable cache.
   if (config_.cache_size > 0) {
-    auto pub_cache_opts = ze_publication_cache_options_default();
-    pub_cache_opts.history = config_.cache_size;
-    pub_cache_ =
-        ze_declare_publication_cache(session_->loan(), z_keyexpr(config_.topic.c_str()), &pub_cache_opts);
-    throwExceptionIf<FailedZenohOperation>(!z_check(pub_cache_), "failed to enable cache");
+    enableCache();
   }
 
   zenohc::PublisherOptions pub_options;
   if (config_.real_time) {
     pub_options.set_priority(zenohc::Priority::Z_PRIORITY_REAL_TIME);
   }
-
   publisher_ = expectAsUniquePtr(session_->declare_publisher(config_.topic, pub_options));
 
-  put_options_.set_encoding(Z_ENCODING_PREFIX_APP_CUSTOM);
-  attachment_[messageCounterKey()] = "0";
-  attachment_[sessionIdKey()] = toString(session_->info_zid());
-  put_options_.set_attachment(attachment_);
+  initAttachments();
 
   if (match_cb_ != nullptr) {
-    using ClosureMatchingListener =
-        zenohc::ClosureConstRefParam<zcu_owned_closure_matching_status_t, zcu_matching_status_t,
-                                     zcu_matching_status_t>;
-    ClosureMatchingListener cb = [this](zcu_matching_status_t matching_status) {
-      MatchingStatus status{ .matching = matching_status.matching };
-      this->match_cb_(status);
-    };
-
-    auto callback = cb.take();
-    subscriers_listener_ = zcu_publisher_matching_listener_callback(publisher_->loan(), z_move(callback));
+    enableMatchingListener();
   }
 
-  auto type_info_json = this->type_info_.toJson();
-  auto type_info_callback = [type_info_json](const auto& request) {
-    (void)request;
-    return type_info_json;
-  };
-  auto type_service_topic = getTypeInfoServiceTopic(config_.topic);
-  type_service_ = std::make_unique<Service>(session_, type_service_topic, std::move(type_info_callback));
+  createTypeInfoService();
 }
 
 Publisher::~Publisher() {
@@ -75,5 +51,44 @@ auto Publisher::publish(std::span<std::byte> data) -> bool {
   attachment_[messageCounterKey()] = std::to_string(pub_msg_count_++);
 
   return publisher_->put({ data.data(), data.size() }, put_options_);
+}
+
+void Publisher::enableCache() {
+  auto pub_cache_opts = ze_publication_cache_options_default();
+  pub_cache_opts.history = config_.cache_size;
+  pub_cache_ =
+      ze_declare_publication_cache(session_->loan(), z_keyexpr(config_.topic.c_str()), &pub_cache_opts);
+  throwExceptionIf<FailedZenohOperation>(!z_check(pub_cache_), "failed to enable cache");
+}
+
+void Publisher::initAttachments() {
+  put_options_.set_encoding(Z_ENCODING_PREFIX_APP_CUSTOM);
+  attachment_[messageCounterKey()] = "0";
+  attachment_[sessionIdKey()] = toString(session_->info_zid());
+  put_options_.set_attachment(attachment_);
+
+  // TODO: add type info.
+}
+
+void Publisher::enableMatchingListener() {
+  using ClosureMatchingListener = zenohc::ClosureConstRefParam<zcu_owned_closure_matching_status_t,
+                                                               zcu_matching_status_t, zcu_matching_status_t>;
+  ClosureMatchingListener cb = [this](zcu_matching_status_t matching_status) {
+    MatchingStatus status{ .matching = matching_status.matching };
+    this->match_cb_(status);
+  };
+
+  auto callback = cb.take();
+  subscriers_listener_ = zcu_publisher_matching_listener_callback(publisher_->loan(), z_move(callback));
+}
+
+void Publisher::createTypeInfoService() {
+  auto type_info_json = this->type_info_.toJson();
+  auto type_info_callback = [type_info_json](const auto& request) {
+    (void)request;
+    return type_info_json;
+  };
+  auto type_service_topic = getTypeInfoServiceTopic(config_.topic);
+  type_service_ = std::make_unique<Service>(session_, type_service_topic, std::move(type_info_callback));
 }
 }  // namespace eolo::ipc::zenoh

--- a/modules/ipc/src/zenoh/publisher.cpp
+++ b/modules/ipc/src/zenoh/publisher.cpp
@@ -57,7 +57,7 @@ Publisher::Publisher(SessionPtr session, Config config, serdes::TypeInfo type_in
     subscriers_listener_ = zcu_publisher_matching_listener_callback(publisher_->loan(), z_move(callback));
   }
 
-  auto type_info_json = toJson(this->type_info_);
+  auto type_info_json = this->type_info_.toJson();
   auto type_info_callback = [type_info_json](const auto& request) {
     (void)request;
     return type_info_json;

--- a/modules/ipc/src/zenoh/service.cpp
+++ b/modules/ipc/src/zenoh/service.cpp
@@ -1,0 +1,24 @@
+//================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#include "eolo/ipc/zenoh/service.h"
+
+namespace eolo::ipc::zenoh {
+
+Service::Service(SessionPtr session, std::string topic, Callback&& callback)
+  : session_(std::move(session)), topic_(std::move(topic)), callback_(std::forward<Callback>(callback)) {
+  auto query = [this](const zenohc::Query& query) {
+    QueryRequest request{ .topic = std::string{ query.get_keyexpr().as_string_view() },
+                          .parameters = std::string{ query.get_parameters().as_string_view() },
+                          .value = std::string{ query.get_value().as_string_view() } };
+    auto result = this->callback_(request);
+
+    zenohc::QueryReplyOptions options;
+    options.set_encoding(zenohc::Encoding{ Z_ENCODING_PREFIX_TEXT_PLAIN });
+    query.reply(query.get_keyexpr(), result, options);
+  };
+
+  queryable_ = expectAsUniquePtr(session_->declare_queryable(topic, { query, []() {} }));
+}
+}  // namespace eolo::ipc::zenoh

--- a/modules/ipc/src/zenoh/service.cpp
+++ b/modules/ipc/src/zenoh/service.cpp
@@ -7,8 +7,8 @@
 namespace eolo::ipc::zenoh {
 
 Service::Service(SessionPtr session, std::string topic, Callback&& callback)
-  : session_(std::move(session)), topic_(std::move(topic)), callback_(std::forward<Callback>(callback)) {
-  auto query = [this](const zenohc::Query& query) {
+  : session_(std::move(session)), topic_(std::move(topic)), callback_(std::move(callback)) {
+  auto query = [this](const zenohc::Query& query) mutable {
     QueryRequest request{ .topic = std::string{ query.get_keyexpr().as_string_view() },
                           .parameters = std::string{ query.get_parameters().as_string_view() },
                           .value = std::string{ query.get_value().as_string_view() } };
@@ -19,6 +19,6 @@ Service::Service(SessionPtr session, std::string topic, Callback&& callback)
     query.reply(query.get_keyexpr(), result, options);
   };
 
-  queryable_ = expectAsUniquePtr(session_->declare_queryable(topic, { query, []() {} }));
+  queryable_ = expectAsUniquePtr(session_->declare_queryable(topic_, { std::move(query), []() {} }));
 }
 }  // namespace eolo::ipc::zenoh

--- a/modules/ipc/src/zenoh/subscriber.cpp
+++ b/modules/ipc/src/zenoh/subscriber.cpp
@@ -37,6 +37,7 @@ void Subscriber::callback(const zenohc::Sample& sample) {
   }
 
   metadata.timestamp = toChrono(sample.get_timestamp());
+  metadata.topic = sample.get_keyexpr().as_string_view();
 
   auto buffer = toByteSpan(sample.get_payload());
   callback_(metadata, buffer);

--- a/modules/serdes/CMakeLists.txt
+++ b/modules/serdes/CMakeLists.txt
@@ -15,14 +15,20 @@ find_package(Protobuf REQUIRED)
 set(SOURCES
     src/serdes.cpp
     src/type_info.cpp
+    src/dynamic_deserializer.cpp
+    src/protobuf/dynamic_deserializer.cpp
     src/protobuf/buffers.cpp
     src/protobuf/protobuf.cpp
+    src/protobuf/protobuf_internal.cpp
     README.md
+    include/eolo/serdes/dynamic_deserializer.h
     include/eolo/serdes/serdes.h
     include/eolo/serdes/type_info.h
     include/eolo/serdes/protobuf/concepts.h
     include/eolo/serdes/protobuf/buffers.h
+    include/eolo/serdes/protobuf/dynamic_deserializer.h
     include/eolo/serdes/protobuf/protobuf.h
+    include/eolo/serdes/protobuf/protobuf_internal.h
 )
 
 # library target

--- a/modules/serdes/CMakeLists.txt
+++ b/modules/serdes/CMakeLists.txt
@@ -5,15 +5,21 @@
 declare_module(
   NAME serdes
   DEPENDS_ON_MODULES base
-  DEPENDS_ON_EXTERNAL_PROJECTS ""
+  DEPENDS_ON_EXTERNAL_PROJECTS magic_enum Protobuf
 )
+
+find_package(magic_enum REQUIRED)
+find_package(Protobuf REQUIRED)
 
 # library sources
 set(SOURCES
     src/serdes.cpp
+    src/type_info.cpp
     src/protobuf/buffers.cpp
     src/protobuf/protobuf.cpp
     README.md
+    include/eolo/serdes/serdes.h
+    include/eolo/serdes/type_info.h
     include/eolo/serdes/protobuf/concepts.h
     include/eolo/serdes/protobuf/buffers.h
     include/eolo/serdes/protobuf/protobuf.h
@@ -22,7 +28,7 @@ set(SOURCES
 # library target
 define_module_library(
   NAME serdes
-  PUBLIC_LINK_LIBS eolo::base
+  PUBLIC_LINK_LIBS eolo::base magic_enum::magic_enum protobuf::libprotobuf
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>

--- a/modules/serdes/include/eolo/serdes/dynamic_deserializer.h
+++ b/modules/serdes/include/eolo/serdes/dynamic_deserializer.h
@@ -1,0 +1,24 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <span>
+
+#include "eolo/serdes/protobuf/dynamic_deserializer.h"
+#include "eolo/serdes/type_info.h"
+
+namespace eolo::serdes {
+
+class DynamicDeserializer {
+public:
+  void registerSchema(const TypeInfo& type_info);
+  [[nodiscard]] auto toJson(const std::string& type, std::span<const std::byte> data) -> std::string;
+
+private:
+  protobuf::DynamicDeserializer proto_deserializer_;
+  std::unordered_map<std::string, TypeInfo::Serialization> type_to_serialization_;
+};
+
+}  // namespace eolo::serdes

--- a/modules/serdes/include/eolo/serdes/protobuf/concepts.h
+++ b/modules/serdes/include/eolo/serdes/protobuf/concepts.h
@@ -7,6 +7,12 @@
 #include <concepts>
 
 namespace eolo::serdes::protobuf {
+
+template <class T>
+struct ProtoAssociation {
+  using Type = void;
+};
+
 template <typename T>
 concept ProtobufMessage = requires(T proto, void* out_data, const void* in_data, int size) {
   { proto.SerializeToArray(out_data, size) };

--- a/modules/serdes/include/eolo/serdes/protobuf/dynamic_deserializer.h
+++ b/modules/serdes/include/eolo/serdes/protobuf/dynamic_deserializer.h
@@ -1,0 +1,30 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <span>
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/descriptor_database.h>
+#include <google/protobuf/dynamic_message.h>
+#include <google/protobuf/util/json_util.h>
+
+#include "eolo/serdes/type_info.h"
+
+namespace eolo::serdes::protobuf {
+
+class DynamicDeserializer {
+public:
+  void registerSchema(const TypeInfo& type_info);
+  [[nodiscard]] auto toJson(const std::string& type, std::span<const std::byte> data) -> std::string;
+
+private:
+  google::protobuf::SimpleDescriptorDatabase proto_db_;
+  google::protobuf::DescriptorPool proto_pool_{ &proto_db_ };
+  google::protobuf::DynamicMessageFactory proto_factory_{ &proto_pool_ };
+};
+
+}  // namespace eolo::serdes::protobuf

--- a/modules/serdes/include/eolo/serdes/protobuf/protobuf.h
+++ b/modules/serdes/include/eolo/serdes/protobuf/protobuf.h
@@ -5,10 +5,20 @@
 #pragma once
 
 #include <eolo/base/exception.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
+#include <range/v3/range/conversion.hpp>
 
 #include "eolo/serdes/protobuf/buffers.h"
+#include "eolo/serdes/type_info.h"
 
 namespace eolo::serdes::protobuf {
+
+template <class T>
+struct ProtoAssociation {
+  using Type = void;
+};
+
 template <class T>
 [[nodiscard]] auto serialize(const T& data) -> std::vector<std::byte>;
 
@@ -28,24 +38,60 @@ auto deserialize(std::span<const std::byte> buffer, T& data) -> void {
   fromProtobuf(des_buffer, data);
 }
 
-template <class Proto, class T>
-void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const T& data)
-  requires ProtobufConvertible<Proto, T>
-{
+// template <class Proto, class T>
+// void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const T& data)
+//   requires ProtobufConvertible<Proto, T>
+// {
+//   Proto proto;
+//   toProto(proto, data);
+//   buffer.serialize(proto);
+// }
+
+// template <class Proto, class T>
+// void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, T& data)
+//   requires ProtobufConvertible<Proto, T>
+// {
+//   Proto proto;
+//   auto res = buffer.deserialize(proto);
+//   throwExceptionIf<InvalidDataException>(!res, "Failed to parse proto::pose from incoming buffer");
+
+//   fromProto(proto, data);
+// }
+template <class T>
+void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const T& data) {
+  using Proto = ProtoAssociation<T>::Type;
   Proto proto;
   toProto(proto, data);
   buffer.serialize(proto);
 }
 
-template <class Proto, class T>
-void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, T& data)
-  requires ProtobufConvertible<Proto, T>
-{
+template <class T>
+void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, T& data) {
+  using Proto = ProtoAssociation<T>::Type;
   Proto proto;
   auto res = buffer.deserialize(proto);
   throwExceptionIf<InvalidDataException>(!res, "Failed to parse proto::pose from incoming buffer");
 
   fromProto(proto, data);
+}
+
+/// Builds a FileDescriptorSet of this descriptor and all transitive dependencies, for use as a
+/// channel schema.
+auto buildFileDescriptorSet(const google::protobuf::Descriptor* toplevel_descriptor)
+    -> google::protobuf::FileDescriptorSet;
+
+template <class T>
+auto getTypeInfo() -> TypeInfo {
+  using Proto = ProtoAssociation<T>::Type;
+  auto proto_descriptor = Proto::descriptor();
+  auto file_descriptor = buildFileDescriptorSet(proto_descriptor).SerializeAsString();
+
+  std::vector<std::byte> schema(file_descriptor.size());
+  std::transform(file_descriptor.begin(), file_descriptor.end(), schema.begin(),
+                 [](char c) { return std::byte{ c }; });
+  return { .name = proto_descriptor->full_name(),
+           .schema = schema,
+           .serialization = TypeInfo::Serialization::PROTOBUF };
 }
 
 }  // namespace eolo::serdes::protobuf

--- a/modules/serdes/include/eolo/serdes/protobuf/protobuf.h
+++ b/modules/serdes/include/eolo/serdes/protobuf/protobuf.h
@@ -5,19 +5,13 @@
 #pragma once
 
 #include <eolo/base/exception.h>
-#include <google/protobuf/descriptor.h>
-#include <google/protobuf/descriptor.pb.h>
 #include <range/v3/range/conversion.hpp>
 
 #include "eolo/serdes/protobuf/buffers.h"
+#include "eolo/serdes/protobuf/protobuf_internal.h"
 #include "eolo/serdes/type_info.h"
 
 namespace eolo::serdes::protobuf {
-
-template <class T>
-struct ProtoAssociation {
-  using Type = void;
-};
 
 template <class T>
 [[nodiscard]] auto serialize(const T& data) -> std::vector<std::byte>;
@@ -25,66 +19,29 @@ template <class T>
 template <class T>
 auto deserialize(std::span<const std::byte> buffer, T& data) -> void;
 
+/// Create the type info for the serialized type associated with `T`.
+template <class T>
+[[nodiscard]] auto getTypeInfo() -> TypeInfo;
+
+// --- Implementation ---
 template <class T>
 auto serialize(const T& data) -> std::vector<std::byte> {
   SerializerBuffer buffer{};
-  toProtobuf(buffer, data);
+  internal::toProtobuf(buffer, data);
   return std::move(buffer).exctractSerializedData();
 }
 
 template <class T>
 auto deserialize(std::span<const std::byte> buffer, T& data) -> void {
   DeserializerBuffer des_buffer{ buffer };
-  fromProtobuf(des_buffer, data);
+  internal::fromProtobuf(des_buffer, data);
 }
-
-// template <class Proto, class T>
-// void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const T& data)
-//   requires ProtobufConvertible<Proto, T>
-// {
-//   Proto proto;
-//   toProto(proto, data);
-//   buffer.serialize(proto);
-// }
-
-// template <class Proto, class T>
-// void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, T& data)
-//   requires ProtobufConvertible<Proto, T>
-// {
-//   Proto proto;
-//   auto res = buffer.deserialize(proto);
-//   throwExceptionIf<InvalidDataException>(!res, "Failed to parse proto::pose from incoming buffer");
-
-//   fromProto(proto, data);
-// }
-template <class T>
-void toProtobuf(serdes::protobuf::SerializerBuffer& buffer, const T& data) {
-  using Proto = ProtoAssociation<T>::Type;
-  Proto proto;
-  toProto(proto, data);
-  buffer.serialize(proto);
-}
-
-template <class T>
-void fromProtobuf(serdes::protobuf::DeserializerBuffer& buffer, T& data) {
-  using Proto = ProtoAssociation<T>::Type;
-  Proto proto;
-  auto res = buffer.deserialize(proto);
-  throwExceptionIf<InvalidDataException>(!res, "Failed to parse proto::pose from incoming buffer");
-
-  fromProto(proto, data);
-}
-
-/// Builds a FileDescriptorSet of this descriptor and all transitive dependencies, for use as a
-/// channel schema.
-auto buildFileDescriptorSet(const google::protobuf::Descriptor* toplevel_descriptor)
-    -> google::protobuf::FileDescriptorSet;
 
 template <class T>
 auto getTypeInfo() -> TypeInfo {
   using Proto = ProtoAssociation<T>::Type;
   auto proto_descriptor = Proto::descriptor();
-  auto file_descriptor = buildFileDescriptorSet(proto_descriptor).SerializeAsString();
+  auto file_descriptor = internal::buildFileDescriptorSet(proto_descriptor).SerializeAsString();
 
   std::vector<std::byte> schema(file_descriptor.size());
   std::transform(file_descriptor.begin(), file_descriptor.end(), schema.begin(),

--- a/modules/serdes/include/eolo/serdes/protobuf/protobuf.h
+++ b/modules/serdes/include/eolo/serdes/protobuf/protobuf.h
@@ -10,6 +10,7 @@
 #include "eolo/serdes/protobuf/buffers.h"
 #include "eolo/serdes/protobuf/protobuf_internal.h"
 #include "eolo/serdes/type_info.h"
+#include "eolo/utils/utils.h"
 
 namespace eolo::serdes::protobuf {
 
@@ -45,10 +46,11 @@ auto getTypeInfo() -> TypeInfo {
 
   std::vector<std::byte> schema(file_descriptor.size());
   std::transform(file_descriptor.begin(), file_descriptor.end(), schema.begin(),
-                 [](char c) { return std::byte{ c }; });
+                 [](char c) { return static_cast<std::byte>(c); });
   return { .name = proto_descriptor->full_name(),
            .schema = schema,
-           .serialization = TypeInfo::Serialization::PROTOBUF };
+           .serialization = TypeInfo::Serialization::PROTOBUF,
+           .original_type = utils::getTypeName<T>() };
 }
 
 }  // namespace eolo::serdes::protobuf

--- a/modules/serdes/include/eolo/serdes/protobuf/protobuf_internal.h
+++ b/modules/serdes/include/eolo/serdes/protobuf/protobuf_internal.h
@@ -1,0 +1,37 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#pragma once
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
+
+#include "eolo/base/exception.h"
+#include "eolo/serdes/protobuf/buffers.h"
+
+namespace eolo::serdes::protobuf::internal {
+
+template <class T>
+void toProtobuf(SerializerBuffer& buffer, const T& data) {
+  using Proto = ProtoAssociation<T>::Type;
+  Proto proto;
+  toProto(proto, data);
+  buffer.serialize(proto);
+}
+
+template <class T>
+void fromProtobuf(DeserializerBuffer& buffer, T& data) {
+  using Proto = ProtoAssociation<T>::Type;
+  Proto proto;
+  auto res = buffer.deserialize(proto);
+  throwExceptionIf<InvalidDataException>(!res, "Failed to parse proto::pose from incoming buffer");
+
+  fromProto(proto, data);
+}
+
+/// Builds a FileDescriptorSet of this descriptor and all transitive dependencies, for use as a
+/// channel schema. The descriptor can be obtained via `ProtoType::descriptor()`.
+auto buildFileDescriptorSet(const google::protobuf::Descriptor* toplevel_descriptor)
+    -> google::protobuf::FileDescriptorSet;
+
+}  // namespace eolo::serdes::protobuf::internal

--- a/modules/serdes/include/eolo/serdes/protobuf/protobuf_internal.h
+++ b/modules/serdes/include/eolo/serdes/protobuf/protobuf_internal.h
@@ -8,6 +8,7 @@
 
 #include "eolo/base/exception.h"
 #include "eolo/serdes/protobuf/buffers.h"
+#include "eolo/utils/utils.h"
 
 namespace eolo::serdes::protobuf::internal {
 
@@ -24,7 +25,8 @@ void fromProtobuf(DeserializerBuffer& buffer, T& data) {
   using Proto = ProtoAssociation<T>::Type;
   Proto proto;
   auto res = buffer.deserialize(proto);
-  throwExceptionIf<InvalidDataException>(!res, "Failed to parse proto::pose from incoming buffer");
+  throwExceptionIf<InvalidDataException>(
+      !res, std::format("Failed to parse {} from incoming buffer", utils::getTypeName<T>()));
 
   fromProto(proto, data);
 }

--- a/modules/serdes/include/eolo/serdes/serdes.h
+++ b/modules/serdes/include/eolo/serdes/serdes.h
@@ -4,17 +4,18 @@
 
 #pragma once
 
-#include "eolo/serdes/protobuf/buffers.h"
+#include <type_traits>
+
 #include "eolo/serdes/protobuf/protobuf.h"
 
 namespace eolo::serdes {
 
 template <class T>
-concept ProtobufSerializable =
-    requires(T proto, protobuf::SerializerBuffer ser_buffer, protobuf::DeserializerBuffer des_buffer) {
-      { toProtobuf(ser_buffer, proto) };
-      { fromProtobuf(des_buffer, proto) };
-    };
+concept ProtobufSerializable = requires(T data) {
+  { !std::is_same_v<typename protobuf::ProtoAssociation<T>::Type, void> };
+};
+
+// ProtoAssociation<T>::Type
 
 template <class T>
 [[nodiscard]] auto serialize(const T& data) -> std::vector<std::byte>;

--- a/modules/serdes/include/eolo/serdes/serdes.h
+++ b/modules/serdes/include/eolo/serdes/serdes.h
@@ -38,4 +38,13 @@ auto deserialize(std::span<const std::byte> buffer, T& data) -> void {
   }
 }
 
+template <class T>
+auto getSerializedTypeInfo() -> TypeInfo {
+  if constexpr (ProtobufSerializable<T>) {
+    return protobuf::getTypeInfo<T>();
+  } else {
+    static_assert(false, "no serialization supported");
+  }
+}
+
 }  // namespace eolo::serdes

--- a/modules/serdes/include/eolo/serdes/type_info.h
+++ b/modules/serdes/include/eolo/serdes/type_info.h
@@ -16,6 +16,8 @@ struct TypeInfo {
   std::vector<std::byte> schema;
   Serialization serialization = Serialization::TEXT;
 
+  std::string original_type;  /// The type that is serialized by this.
+
   [[nodiscard]] auto toJson() const -> std::string;
   [[nodiscard]] static auto fromJson(const std::string& info) -> TypeInfo;
 };

--- a/modules/serdes/include/eolo/serdes/type_info.h
+++ b/modules/serdes/include/eolo/serdes/type_info.h
@@ -1,0 +1,23 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace eolo::serdes {
+
+struct TypeInfo {
+  enum class Serialization : uint8_t { TEXT = 0, JSON, PROTOBUF };
+
+  std::string name;
+  std::vector<std::byte> schema;
+  Serialization serialization = Serialization::TEXT;
+};
+
+[[nodiscard]] auto toJson(const TypeInfo& info) -> std::string;
+[[nodiscard]] auto fromJson(const std::string& info) -> TypeInfo;
+
+}  // namespace eolo::serdes

--- a/modules/serdes/include/eolo/serdes/type_info.h
+++ b/modules/serdes/include/eolo/serdes/type_info.h
@@ -15,9 +15,9 @@ struct TypeInfo {
   std::string name;
   std::vector<std::byte> schema;
   Serialization serialization = Serialization::TEXT;
-};
 
-[[nodiscard]] auto toJson(const TypeInfo& info) -> std::string;
-[[nodiscard]] auto fromJson(const std::string& info) -> TypeInfo;
+  [[nodiscard]] auto toJson() const -> std::string;
+  [[nodiscard]] static auto fromJson(const std::string& info) -> TypeInfo;
+};
 
 }  // namespace eolo::serdes

--- a/modules/serdes/src/dynamic_deserializer.cpp
+++ b/modules/serdes/src/dynamic_deserializer.cpp
@@ -1,0 +1,37 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#include "eolo/serdes/dynamic_deserializer.h"
+
+#include <cstddef>
+
+#include "eolo/base/exception.h"
+#include "eolo/serdes/type_info.h"
+
+namespace eolo::serdes {
+
+void DynamicDeserializer::registerSchema(const TypeInfo& type_info) {
+  switch (type_info.serialization) {
+    case TypeInfo::Serialization::PROTOBUF:
+      proto_deserializer_.registerSchema(type_info);
+      [[fallthrough]];
+    case TypeInfo::Serialization::JSON:
+      [[fallthrough]];
+    case TypeInfo::Serialization::TEXT:
+      type_to_serialization_[type_info.name] = type_info.serialization;
+  }
+}
+
+auto DynamicDeserializer::toJson(const std::string& type, std::span<const std::byte> data) -> std::string {
+  switch (type_to_serialization_[type]) {
+    case TypeInfo::Serialization::PROTOBUF:
+      return proto_deserializer_.toJson(type, data);
+    case TypeInfo::Serialization::JSON:
+      [[fallthrough]];
+    case TypeInfo::Serialization::TEXT:
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      return std::string{ reinterpret_cast<const char*>(data.data()), data.size() };
+  }
+}
+}  // namespace eolo::serdes

--- a/modules/serdes/src/dynamic_deserializer.cpp
+++ b/modules/serdes/src/dynamic_deserializer.cpp
@@ -4,9 +4,6 @@
 
 #include "eolo/serdes/dynamic_deserializer.h"
 
-#include <cstddef>
-
-#include "eolo/base/exception.h"
 #include "eolo/serdes/type_info.h"
 
 namespace eolo::serdes {

--- a/modules/serdes/src/protobuf/dynamic_deserializer.cpp
+++ b/modules/serdes/src/protobuf/dynamic_deserializer.cpp
@@ -1,0 +1,61 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#include "eolo/serdes/protobuf/dynamic_deserializer.h"
+
+#include <cstddef>
+
+#include "eolo/base/exception.h"
+
+namespace eolo::serdes::protobuf {
+namespace {
+void loadSchema(const eolo::serdes::TypeInfo& type_info,
+                google::protobuf::SimpleDescriptorDatabase& proto_db) {
+  google::protobuf::FileDescriptorSet fd_set;
+  auto res = fd_set.ParseFromArray(type_info.schema.data(), static_cast<int>(type_info.schema.size()));
+  throwExceptionIf<InvalidDataException>(!res,
+                                         std::format("failed to parse schema for type: {}", type_info.name));
+
+  google::protobuf::FileDescriptorProto unused;
+  for (int i = 0; i < fd_set.file_size(); ++i) {
+    const auto& file = fd_set.file(i);
+    if (!proto_db.FindFileByName(file.name(), &unused)) {
+      res = proto_db.Add(file);
+      throwExceptionIf<InvalidDataException>(
+          !res, std::format("failed to add definition to proto DB: {}", file.name()));
+    }
+  }
+}
+}  // namespace
+
+void DynamicDeserializer::registerSchema(const TypeInfo& type_info) {
+  const auto* descriptor = proto_pool_.FindMessageTypeByName(type_info.name);
+  if (descriptor != nullptr) {
+    return;
+  }
+
+  loadSchema(type_info, proto_db_);
+}
+
+auto DynamicDeserializer::toJson(const std::string& type, std::span<const std::byte> data) -> std::string {
+  const auto* descriptor = proto_pool_.FindMessageTypeByName(type);
+  throwExceptionIf<InvalidDataException>(
+      descriptor == nullptr,
+      std::format("schema for type {} was not registered, cannot deserialize data", type));
+
+  auto* message = proto_factory_.GetPrototype(descriptor)->New();
+  const auto res = message->ParseFromArray(data.data(), static_cast<int>(data.size()));
+  throwExceptionIf<InvalidDataException>(!res, std::format("failed to parse message of type {}", type));
+
+  std::string msg_json;
+  google::protobuf::util::JsonPrintOptions options;
+  options.always_print_primitive_fields = true;
+  auto status = google::protobuf::util::MessageToJsonString(*message, &msg_json);
+  throwExceptionIf<InvalidDataException>(
+      !status.ok(), std::format("failed to convert proto message to json: {}", status.message()));
+
+  return msg_json;
+}
+
+}  // namespace eolo::serdes::protobuf

--- a/modules/serdes/src/protobuf/protobuf.cpp
+++ b/modules/serdes/src/protobuf/protobuf.cpp
@@ -4,27 +4,4 @@
 
 #include "eolo/serdes/protobuf/protobuf.h"
 
-namespace eolo::serdes::protobuf {
-auto buildFileDescriptorSet(const google::protobuf::Descriptor* toplevel_descriptor)
-    -> google::protobuf::FileDescriptorSet {
-  google::protobuf::FileDescriptorSet fd_set;
-  std::queue<const google::protobuf::FileDescriptor*> to_add;
-  to_add.push(toplevel_descriptor->file());
-  std::unordered_set<std::string> seen_dependencies;
-
-  while (!to_add.empty()) {
-    const google::protobuf::FileDescriptor* next = to_add.front();
-    to_add.pop();
-    next->CopyTo(fd_set.add_file());
-    for (int i = 0; i < next->dependency_count(); ++i) {
-      const auto& dep = next->dependency(i);
-      if (seen_dependencies.find(dep->name()) == seen_dependencies.end()) {
-        seen_dependencies.insert(dep->name());
-        to_add.push(dep);
-      }
-    }
-  }
-
-  return fd_set;
-}
-}  // namespace eolo::serdes::protobuf
+namespace eolo::serdes::protobuf {}  // namespace eolo::serdes::protobuf

--- a/modules/serdes/src/protobuf/protobuf.cpp
+++ b/modules/serdes/src/protobuf/protobuf.cpp
@@ -4,4 +4,27 @@
 
 #include "eolo/serdes/protobuf/protobuf.h"
 
-namespace eolo::protobuf {}
+namespace eolo::serdes::protobuf {
+auto buildFileDescriptorSet(const google::protobuf::Descriptor* toplevel_descriptor)
+    -> google::protobuf::FileDescriptorSet {
+  google::protobuf::FileDescriptorSet fd_set;
+  std::queue<const google::protobuf::FileDescriptor*> to_add;
+  to_add.push(toplevel_descriptor->file());
+  std::unordered_set<std::string> seen_dependencies;
+
+  while (!to_add.empty()) {
+    const google::protobuf::FileDescriptor* next = to_add.front();
+    to_add.pop();
+    next->CopyTo(fd_set.add_file());
+    for (int i = 0; i < next->dependency_count(); ++i) {
+      const auto& dep = next->dependency(i);
+      if (seen_dependencies.find(dep->name()) == seen_dependencies.end()) {
+        seen_dependencies.insert(dep->name());
+        to_add.push(dep);
+      }
+    }
+  }
+
+  return fd_set;
+}
+}  // namespace eolo::serdes::protobuf

--- a/modules/serdes/src/protobuf/protobuf_internal.cpp
+++ b/modules/serdes/src/protobuf/protobuf_internal.cpp
@@ -1,0 +1,30 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#include "eolo/serdes/protobuf/protobuf_internal.h"
+
+namespace eolo::serdes::protobuf::internal {
+auto buildFileDescriptorSet(const google::protobuf::Descriptor* toplevel_descriptor)
+    -> google::protobuf::FileDescriptorSet {
+  google::protobuf::FileDescriptorSet fd_set;
+  std::queue<const google::protobuf::FileDescriptor*> to_add;
+  to_add.push(toplevel_descriptor->file());
+  std::unordered_set<std::string> seen_dependencies;
+
+  while (!to_add.empty()) {
+    const google::protobuf::FileDescriptor* next = to_add.front();
+    to_add.pop();
+    next->CopyTo(fd_set.add_file());
+    for (int i = 0; i < next->dependency_count(); ++i) {
+      const auto& dep = next->dependency(i);
+      if (seen_dependencies.find(dep->name()) == seen_dependencies.end()) {
+        seen_dependencies.insert(dep->name());
+        to_add.push(dep);
+      }
+    }
+  }
+
+  return fd_set;
+}
+}  // namespace eolo::serdes::protobuf::internal

--- a/modules/serdes/src/serdes.cpp
+++ b/modules/serdes/src/serdes.cpp
@@ -3,3 +3,5 @@
 //=================================================================================================
 
 #include "eolo/serdes/serdes.h"
+
+namespace eolo::serdes {}  // namespace eolo::serdes

--- a/modules/serdes/src/type_info.cpp
+++ b/modules/serdes/src/type_info.cpp
@@ -1,0 +1,33 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 EOLO Contributors
+//=================================================================================================
+
+#include "eolo/serdes/type_info.h"
+
+#include <fmt/core.h>
+#include <magic_enum.hpp>
+#include <nlohmann/json.hpp>
+
+#include "eolo/base/exception.h"
+
+namespace eolo::serdes {
+
+[[nodiscard]] auto toJson(const TypeInfo& info) -> std::string {
+  nlohmann::json data;
+  data["name"] = info.name;
+  data["schema"] = info.schema;
+  data["serialization"] = magic_enum::enum_name(info.serialization);
+  auto res = data.dump();
+  return data.dump();
+}
+
+[[nodiscard]] auto fromJson(const std::string& info) -> TypeInfo {
+  auto data = nlohmann::json::parse(info);
+  auto serialization_str = data["serialization"].get<std::string>();
+  auto serialization = magic_enum::enum_cast<TypeInfo::Serialization>(serialization_str);
+  throwExceptionIf<InvalidDataException>(
+      !serialization.has_value(),
+      std::format("failed to convert {} to Serialization enum", serialization_str));
+  return { .name = data["name"], .schema = data["schema"], .serialization = serialization.value() };
+}
+}  // namespace eolo::serdes

--- a/modules/serdes/src/type_info.cpp
+++ b/modules/serdes/src/type_info.cpp
@@ -18,6 +18,7 @@ auto TypeInfo::toJson() const -> std::string {
   data["name"] = name;
   data["schema"] = schema;
   data["serialization"] = magic_enum::enum_name(serialization);
+  data["original_type"] = original_type;
   auto res = data.dump();
   return data.dump();
 }
@@ -29,6 +30,9 @@ auto TypeInfo::fromJson(const std::string& info) -> TypeInfo {
   throwExceptionIf<InvalidDataException>(
       !serialization.has_value(),
       std::format("failed to convert {} to Serialization enum", serialization_str));
-  return { .name = data["name"], .schema = data["schema"], .serialization = serialization.value() };
+  return { .name = data["name"],
+           .schema = data["schema"],
+           .serialization = serialization.value(),
+           .original_type = data["original_type"] };
 }
 }  // namespace eolo::serdes

--- a/modules/serdes/src/type_info.cpp
+++ b/modules/serdes/src/type_info.cpp
@@ -11,17 +11,18 @@
 #include "eolo/base/exception.h"
 
 namespace eolo::serdes {
+// TODO(filippo): add tests.
 
-[[nodiscard]] auto toJson(const TypeInfo& info) -> std::string {
+auto TypeInfo::toJson() const -> std::string {
   nlohmann::json data;
-  data["name"] = info.name;
-  data["schema"] = info.schema;
-  data["serialization"] = magic_enum::enum_name(info.serialization);
+  data["name"] = name;
+  data["schema"] = schema;
+  data["serialization"] = magic_enum::enum_name(serialization);
   auto res = data.dump();
   return data.dump();
 }
 
-[[nodiscard]] auto fromJson(const std::string& info) -> TypeInfo {
+auto TypeInfo::fromJson(const std::string& info) -> TypeInfo {
   auto data = nlohmann::json::parse(info);
   auto serialization_str = data["serialization"].get<std::string>();
   auto serialization = magic_enum::enum_cast<TypeInfo::Serialization>(serialization_str);

--- a/modules/serdes/tests/tests.cpp
+++ b/modules/serdes/tests/tests.cpp
@@ -27,6 +27,21 @@ public:
   MOCK_METHOD(bool, ParseFromArray, (const void*, int), (const));
 };
 
+struct Data {
+  int a = NUMBER;
+};
+
+}  // namespace eolo::serdes::tests
+
+namespace eolo::serdes::protobuf {
+template <>
+struct ProtoAssociation<eolo::serdes::tests::Data> {
+  using Type = eolo::serdes::tests::MockProtoMessage;
+};
+}  // namespace eolo::serdes::protobuf
+
+namespace eolo::serdes::tests {
+
 TEST(Protobuf, SerializerBuffers) {
   protobuf::SerializerBuffer buffer;
   MockProtoMessage proto;
@@ -55,19 +70,12 @@ TEST(Protobuf, DeserializerBuffers) {
   EXPECT_TRUE(res);
 }
 
-struct Data {
-  int a = NUMBER;
-};
-
-void toProtobuf(protobuf::SerializerBuffer& buffer, const Data& data) {
-  MockProtoMessage proto;
+void toProto(MockProtoMessage& proto, const Data& data) {
   EXPECT_CALL(proto, ByteSizeLong).Times(1).WillOnce(Return(data.a));
-
-  buffer.serialize(proto);
 }
 
-void fromProtobuf(const protobuf::DeserializerBuffer& buffer, Data& data) {
-  (void)buffer;
+void fromProto(const MockProtoMessage& proto, Data& data) {
+  (void)proto;
   data.a = NUMBER * 2;
 }
 
@@ -76,6 +84,7 @@ TEST(Serialization, Protobuf) {
   auto buffer = serialize(data);
   EXPECT_THAT(buffer, SizeIs(NUMBER));
 
+  DefaultValue<bool>::Set(true);
   deserialize(buffer, data);
   EXPECT_EQ(data.a, NUMBER * 2);
 }

--- a/modules/utils/src/version_impl.h
+++ b/modules/utils/src/version_impl.h
@@ -19,6 +19,6 @@ static constexpr std::uint16_t VERSION_PATCH = 1;
 
 static constexpr std::string_view REPO_BRANCH = "mcap";
 static constexpr std::string_view BUILD_PROFILE = "Release";
-static constexpr std::string_view REPO_HASH = "797b812";
+static constexpr std::string_view REPO_HASH = "7b6e068";
 
 } // namespace eolo::utils

--- a/modules/utils/src/version_impl.h
+++ b/modules/utils/src/version_impl.h
@@ -19,6 +19,6 @@ static constexpr std::uint16_t VERSION_PATCH = 1;
 
 static constexpr std::string_view REPO_BRANCH = "mcap";
 static constexpr std::string_view BUILD_PROFILE = "Release";
-static constexpr std::string_view REPO_HASH = "93fc7a8";
+static constexpr std::string_view REPO_HASH = "797b812";
 
 } // namespace eolo::utils

--- a/modules/utils/src/version_impl.h
+++ b/modules/utils/src/version_impl.h
@@ -19,6 +19,6 @@ static constexpr std::uint16_t VERSION_PATCH = 1;
 
 static constexpr std::string_view REPO_BRANCH = "mcap";
 static constexpr std::string_view BUILD_PROFILE = "Release";
-static constexpr std::string_view REPO_HASH = "7b6e068";
+static constexpr std::string_view REPO_HASH = "2013fba";
 
 } // namespace eolo::utils

--- a/modules/utils/src/version_impl.h
+++ b/modules/utils/src/version_impl.h
@@ -19,6 +19,6 @@ static constexpr std::uint16_t VERSION_PATCH = 1;
 
 static constexpr std::string_view REPO_BRANCH = "mcap";
 static constexpr std::string_view BUILD_PROFILE = "Release";
-static constexpr std::string_view REPO_HASH = "83a452a";
+static constexpr std::string_view REPO_HASH = "93fc7a8";
 
 } // namespace eolo::utils

--- a/modules/utils/src/version_impl.h
+++ b/modules/utils/src/version_impl.h
@@ -17,8 +17,8 @@ static constexpr std::uint8_t VERSION_MAJOR = 0;
 static constexpr std::uint8_t VERSION_MINOR = 0;
 static constexpr std::uint16_t VERSION_PATCH = 1;
 
-static constexpr std::string_view REPO_BRANCH = "cmake_split_function";
+static constexpr std::string_view REPO_BRANCH = "mcap";
 static constexpr std::string_view BUILD_PROFILE = "Release";
-static constexpr std::string_view REPO_HASH = "ff16599";
+static constexpr std::string_view REPO_HASH = "83a452a";
 
 } // namespace eolo::utils


### PR DESCRIPTION
# Description
- Add Mcap dependencies and example
- Improved serdes interface and simplified protobuf support
- Publisher now expose published type schema via service
- Add json deserializer for arbitrary types based on the schema
- Add zenoh service

## Type of change
- New feature (non-breaking change which adds functionality)